### PR TITLE
🔧firefoxでのエラー対策

### DIFF
--- a/src/components/messageInputContainer.tsx
+++ b/src/components/messageInputContainer.tsx
@@ -62,6 +62,10 @@ export const MessageInputContainer = ({
     const SpeechRecognition =
       window.webkitSpeechRecognition || window.SpeechRecognition;
 
+    // FirefoxなどSpeechRecognition非対応環境対策
+    if (!SpeechRecognition) {
+      return;
+    }
     const recognition = new SpeechRecognition();
     recognition.lang = "ja-JP";
     recognition.interimResults = true; // 認識の途中結果を返す


### PR DESCRIPTION
SpeechRecognitionはFirefoxでは呼べないためUI表示前にエラーになっていました。ひとまずif文で抜ければFirefoxでもVRMを表示してテキスト入力で会話できました。

参考: https://caniuse.com/speech-recognition

# before

![image](https://user-images.githubusercontent.com/67293653/235313860-ea84394d-d8c4-4369-8bfe-3ba983800ad9.png)

# after

![image](https://user-images.githubusercontent.com/67293653/235313892-de0b488f-804b-451a-b454-f88c7a625404.png)
![image](https://user-images.githubusercontent.com/67293653/235313953-0f08b924-42f5-4e03-b9ee-9c10c5c624c8.png)
