### PR TITLE
Azure OpenAI ServiceのChatGPTも選択できるように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ ChatVRMの各機能は主に以下の技術を使用しています。
 - ユーザーの音声の認識
     - [Web Speech API(SpeechRecognition)](https://developer.mozilla.org/ja/docs/Web/API/SpeechRecognition)
 - 返答文の生成
-    - [ChatGPT API](https://platform.openai.com/docs/api-reference/chat)
+    - [ChatGPT API(OpenAI)](https://platform.openai.com/docs/api-reference/chat)
+    - [ChatGPT API(Azure OpenAI Service)](https://learn.microsoft.com/ja-jp/azure/cognitive-services/openai/reference#completions)
 - 読み上げ音声の生成
     - [Koeiro API](http://koeiromap.rinna.jp/)
 - 3Dキャラクターの表示
@@ -50,11 +51,16 @@ npm run dev
 ## ChatGPT API
 
 ChatVRMでは返答文の生成にChatGPT APIを使用しています。
+OpenAIとAzure OpenAI ServiceのChatGPT APIに対応しています。
 
 ChatGPT APIの仕様や利用規約については以下のリンクや公式サイトをご確認ください。
 
-- [https://platform.openai.com/docs/api-reference/chat](https://platform.openai.com/docs/api-reference/chat)
-- [https://openai.com/policies/api-data-usage-policies](https://openai.com/policies/api-data-usage-policies)
+- OpenAI
+    - [https://platform.openai.com/docs/api-reference/chat](https://platform.openai.com/docs/api-reference/chat)
+    - [https://openai.com/policies/api-data-usage-policies](https://openai.com/policies/api-data-usage-policies)
+- Azure OpenAI Service
+    - [https://learn.microsoft.com/ja-jp/azure/cognitive-services/openai/reference#completions](https://learn.microsoft.com/ja-jp/azure/cognitive-services/openai/reference#completions)
+    - [https://learn.microsoft.com/ja-jp/legal/cognitive-services/openai/code-of-conduct](https://learn.microsoft.com/ja-jp/legal/cognitive-services/openai/code-of-conduct)
 
 
 ## Koeiro API

--- a/src/components/introduction.tsx
+++ b/src/components/introduction.tsx
@@ -1,11 +1,27 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Link } from "./link";
 
 type Props = {
   openAiKey: string;
+  azureOpenAiKey: string;
+  azureOpenAiResourceName: string;
+  azureOpenAiDeploymentName: string;
   onChangeAiKey: (openAiKey: string) => void;
+  onChangeAzureOpenAiKey: (azureOpenAiKey: string) => void;
+  onChangeAzureOpenAiResourceName: (azureOpenAiResourceName: string) => void;
+  onChangeAzureOpenAiDeploymentName: (azureOpenAiDeploymentName: string) => void;
 };
-export const Introduction = ({ openAiKey, onChangeAiKey }: Props) => {
+
+export const Introduction = ({
+  openAiKey,
+  azureOpenAiKey,
+  azureOpenAiResourceName,
+  azureOpenAiDeploymentName,
+  onChangeAiKey,
+  onChangeAzureOpenAiKey,
+  onChangeAzureOpenAiResourceName,
+  onChangeAzureOpenAiDeploymentName,
+}: Props) => {
   const [opened, setOpened] = useState(true);
 
   const handleAiKeyChange = useCallback(
@@ -14,6 +30,43 @@ export const Introduction = ({ openAiKey, onChangeAiKey }: Props) => {
     },
     [onChangeAiKey]
   );
+
+  const handleAzureOpenAiKeyChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChangeAzureOpenAiKey(event.target.value);
+    },
+    [onChangeAzureOpenAiKey]
+  );
+
+  const handleAzureOpenAiResourceNameChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChangeAzureOpenAiResourceName(event.target.value);
+    },
+    [onChangeAzureOpenAiResourceName]
+  );
+
+  const handleAzureOpenAiDeploymentNameChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChangeAzureOpenAiDeploymentName(event.target.value);
+    },
+    [onChangeAzureOpenAiDeploymentName]
+  );
+
+  const [provider, setProvider] = useState("openai");
+
+  const handleProviderChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setProvider(event.target.value);
+  }, []);
+
+  useEffect(() => {
+    if (provider === "openai") {
+      onChangeAzureOpenAiKey("");
+      onChangeAzureOpenAiResourceName("");
+      onChangeAzureOpenAiDeploymentName("");
+    } else {
+      onChangeAiKey("");
+    }
+  }, [provider, onChangeAiKey, onChangeAzureOpenAiKey, onChangeAzureOpenAiResourceName, onChangeAzureOpenAiDeploymentName]);
 
   return opened ? (
     <div className="absolute z-40 w-full h-full px-24 py-40  bg-black/30 font-M_PLUS_2">
@@ -41,9 +94,16 @@ export const Introduction = ({ openAiKey, onChangeAiKey }: Props) => {
               url={
                 "https://openai.com/blog/introducing-chatgpt-and-whisper-apis"
               }
-              label={"ChatGPT API"}
+              label={"ChatGPT API (OpenAI)"}
             />
-            音声合成には
+            と
+            <Link
+              url={
+                "https://azure.microsoft.com/ja-JP/blog/chatgpt-is-now-available-in-azure-openai-service/"
+              }
+              label={"ChatGPT API (Azure OpenAI Service)"}
+            />
+            を、音声合成には
             <Link url={"http://koeiromap.rinna.jp/"} label={"Koeiro API"} />
             を使用しています。 詳細はこちらの
             <Link
@@ -73,29 +133,101 @@ export const Introduction = ({ openAiKey, onChangeAiKey }: Props) => {
         </div>
         <div className="my-24">
           <div className="my-8 font-bold typography-20 text-secondary">
-            OpenAI APIキー
+            ChatGPT APIキー
           </div>
-          <input
-            type="text"
-            placeholder="sk-..."
-            value={openAiKey}
-            onChange={handleAiKeyChange}
-            className="my-4 px-16 py-8 w-full h-40 bg-surface3 hover:bg-surface3-hover rounded-4 text-ellipsis"
-          ></input>
-          <div>
-            APIキーは
-            <Link
-              url="https://platform.openai.com/account/api-keys"
-              label="OpenAIのサイト"
-            />
-            で取得できます。取得したAPIキーをフォームに入力してください。
+          <div className="mb-16">
+            OpenAIまたはAzure OpenAI ServiceのいずれかのAPIキーを入力してください。
           </div>
-          <div className="my-16">
-            入力されたAPIキーで、ブラウザから直接OpenAIのAPIを利用しますので、サーバー等には保存されません。
-            なお、利用しているモデルはGPT-3です。
-            <br />
-            ※APIキーや会話文はピクシブのサーバーに送信されません。
+          <div className="block mb-2 text-secondary">
+            プロバイダー
           </div>
+          <select
+            value={provider}
+            onChange={handleProviderChange}
+            className="my-4 px-16 py-8 w-1/2 h-40 bg-surface3 hover:bg-surface3-hover rounded-4 text-ellipsis"
+          >
+            <option value="openai">OpenAI</option>
+            <option value="azure_openai">Azure OpenAI Service</option>
+          </select>
+          {provider === "openai" ? (
+            <div className="my-8">
+              <div className="block mb-2 text-secondary">
+                APIキー
+              </div>
+              <input
+                type="text"
+                placeholder="sk-..."
+                value={openAiKey}
+                onChange={handleAiKeyChange}
+                className="my-4 px-16 py-8 w-full h-40 bg-surface3 hover:bg-surface3-hover rounded-4 text-ellipsis"
+              />
+              <div>
+                APIキーは
+                <Link
+                  url="https://platform.openai.com/account/api-keys"
+                  label="OpenAIのサイト"
+                />
+                で取得できます。取得したAPIキーをフォームに入力してください。
+              </div>
+              <div className="my-16">
+                入力されたAPIキーで、ブラウザから直接OpenAIのAPIを利用しますので、サーバー等には保存されません。
+                なお、利用しているモデルはGPT-3です。
+                <br />
+                ※APIキーや会話文はピクシブのサーバーに送信されません。
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="my-8">
+                <div className="block mb-2 text-secondary">
+                  APIキー
+                </div>
+                <input
+                  type="text"
+                  placeholder="YOUR_API_KEY"
+                  value={azureOpenAiKey}
+                  onChange={handleAzureOpenAiKeyChange}
+                  className="my-4 px-16 py-8 w-full h-40 bg-surface3 hover:bg-surface3-hover rounded-4 text-ellipsis"
+                />
+              </div>
+              <div className="my-8">
+                <div className="block mb-2 text-secondary">
+                  リソース名
+                </div>
+                <input
+                  type="text"
+                  placeholder="YOUR_RESOURCE_NAME"
+                  value={azureOpenAiResourceName}
+                  onChange={handleAzureOpenAiResourceNameChange}
+                  className="my-4 px-16 py-8 w-full h-40 bg-surface3 hover:bg-surface3-hover rounded-4 text-ellipsis"
+                />
+              </div>
+              <div className="my-8">
+                <div className="block mb-2 text-secondary">
+                  モデルのデプロイ名
+                </div>
+                <input
+                  type="text"
+                  placeholder="YOUR_DEPLOYMENT_NAME"
+                  value={azureOpenAiDeploymentName}
+                  onChange={handleAzureOpenAiDeploymentNameChange}
+                  className="my-4 px-16 py-8 w-full h-40 bg-surface3 hover:bg-surface3-hover rounded-4 text-ellipsis"
+                />
+              </div>
+              <div>
+                <Link
+                  url="https://learn.microsoft.com/ja-jp/azure/cognitive-services/openai/reference"
+                  label="Azure OpenAI ServiceのREST APIリファレンス"
+                />
+                を参考にして各項目を入力してください。
+              </div>
+              <div className="my-16">
+                入力されたAPIキーで、ブラウザから直接Azure OpenAI ServiceのAPIを利用しますので、サーバー等には保存されません。
+                <br />
+                ※APIキーや会話文はピクシブのサーバーに送信されません。
+              </div>
+            </>
+          )}
         </div>
         <div className="my-24">
           <button

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -9,23 +9,35 @@ import { AssistantText } from "./assistantText";
 
 type Props = {
   openAiKey: string;
+  azureOpenAiKey: string;
+  azureOpenAiResourceName: string;
+  azureOpenAiDeploymentName: string;
   systemPrompt: string;
   chatLog: Message[];
   koeiroParam: KoeiroParam;
   assistantMessage: string;
   onChangeSystemPrompt: (systemPrompt: string) => void;
   onChangeAiKey: (key: string) => void;
+  onChangeAzureOpenAiKey: (key: string) => void;
+  onChangeAzureOpenAiResourceName: (resourceName: string) => void;
+  onChangeAzureOpenAiDeploymentName: (deploymentName: string) => void;
   onChangeChatLog: (index: number, text: string) => void;
   onChangeKoeiromapParam: (param: KoeiroParam) => void;
 };
 export const Menu = ({
   openAiKey,
+  azureOpenAiKey,
+  azureOpenAiResourceName,
+  azureOpenAiDeploymentName,
   systemPrompt,
   chatLog,
   koeiroParam,
   assistantMessage,
   onChangeSystemPrompt,
   onChangeAiKey,
+  onChangeAzureOpenAiKey,
+  onChangeAzureOpenAiResourceName,
+  onChangeAzureOpenAiDeploymentName,
   onChangeChatLog,
   onChangeKoeiromapParam,
 }: Props) => {
@@ -46,6 +58,27 @@ export const Menu = ({
       onChangeAiKey(event.target.value);
     },
     [onChangeAiKey]
+  );
+
+  const handleAzureOpenAiKeyChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChangeAzureOpenAiKey(event.target.value);
+    },
+    [onChangeAzureOpenAiKey]
+  );
+
+  const handleAzureOpenAiResourceNameChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChangeAzureOpenAiResourceName(event.target.value);
+    },
+    [onChangeAzureOpenAiResourceName]
+  );
+
+  const handleAzureOpenAiDeploymentNameChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChangeAzureOpenAiDeploymentName(event.target.value);
+    },
+    [onChangeAzureOpenAiDeploymentName]
   );
 
   const handleChangeKoeiroParam = useCallback(
@@ -115,11 +148,17 @@ export const Menu = ({
       {showSettings && (
         <Settings
           openAiKey={openAiKey}
+          azureOpenAiKey={azureOpenAiKey}
+          azureOpenAiResourceName={azureOpenAiResourceName}
+          azureOpenAiDeploymentName={azureOpenAiDeploymentName}          
           chatLog={chatLog}
           systemPrompt={systemPrompt}
           koeiroParam={koeiroParam}
           onClickClose={() => setShowSettings(false)}
           onChangeAiKey={handleAiKeyChange}
+          onChangeAzureOpenAiKey={handleAzureOpenAiKeyChange}
+          onChangeAzureOpenAiResourceName={handleAzureOpenAiResourceNameChange}
+          onChangeAzureOpenAiDeploymentName={handleAzureOpenAiDeploymentNameChange}          
           onChangeSystemPrompt={handleChangeSystemPrompt}
           onChangeChatLog={onChangeChatLog}
           onChangeKoeiroParam={handleChangeKoeiroParam}

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useState, useCallback } from "react";
 import { IconButton } from "./iconButton";
 import { TextButton } from "./textButton";
 import { Message } from "@/features/messages/messages";
@@ -13,11 +14,17 @@ import { Link } from "./link";
 
 type Props = {
   openAiKey: string;
+  azureOpenAiKey: string;
+  azureOpenAiResourceName: string;
+  azureOpenAiDeploymentName: string;
   systemPrompt: string;
   chatLog: Message[];
   koeiroParam: KoeiroParam;
   onClickClose: () => void;
   onChangeAiKey: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeAzureOpenAiKey: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeAzureOpenAiResourceName: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeAzureOpenAiDeploymentName: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onChangeSystemPrompt: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onChangeChatLog: (index: number, text: string) => void;
   onChangeKoeiroParam: (x: number, y: number) => void;
@@ -25,16 +32,26 @@ type Props = {
 };
 export const Settings = ({
   openAiKey,
+  azureOpenAiKey,
+  azureOpenAiResourceName,
+  azureOpenAiDeploymentName,
   chatLog,
   systemPrompt,
   koeiroParam,
   onClickClose,
   onChangeSystemPrompt,
   onChangeAiKey,
+  onChangeAzureOpenAiKey,
+  onChangeAzureOpenAiResourceName,
+  onChangeAzureOpenAiDeploymentName,
   onChangeChatLog,
   onChangeKoeiroParam,
   onClickOpenVrmFile,
 }: Props) => {
+  const [provider, setProvider] = useState("openai");
+  const handleProviderChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setProvider(event.target.value);
+  }, []);
   return (
     <div className="absolute z-40 w-full h-full bg-white/80 backdrop-blur ">
       <div className="absolute m-24">
@@ -48,28 +65,97 @@ export const Settings = ({
         <div className="text-text1 max-w-3xl mx-auto px-24 py-64 ">
           <div className="my-24 typography-32 font-bold">設定</div>
           <div className="my-24">
-            <div className="my-16 typography-20 font-bold">OpenAI API キー</div>
-            <input
-              className="text-ellipsis px-16 py-8 w-col-span-2 bg-surface1 hover:bg-surface1-hover rounded-8"
-              type="text"
-              placeholder="sk-..."
-              value={openAiKey}
-              onChange={onChangeAiKey}
-            />
-            <div>
-              APIキーは
-              <Link
-                url="https://platform.openai.com/account/api-keys"
-                label="OpenAIのサイト"
+            <div className="my-16 typography-20 font-bold">
+              ChatGPT APIキー
+            </div>
+            <div className="mt-16">プロバイダー</div>
+            <select
+              value={provider}
+              onChange={handleProviderChange}
+              className="text-ellipsis px-16 py-8 w-1/2 bg-surface1 hover:bg-surface1-hover rounded-8"
+            >
+              <option value="openai">OpenAI</option>
+              <option value="azure_openai">Azure OpenAI Service</option>
+            </select>
+            {provider === "openai" ? (
+            <div className="my-8">
+              <div className="mt-16">
+                APIキー
+              </div>
+              <input
+                type="text"
+                placeholder="sk-..."
+                value={openAiKey}
+                onChange={onChangeAiKey}
+                className="text-ellipsis px-16 py-8 w-full bg-surface1 hover:bg-surface1-hover rounded-8"
               />
-              で取得できます。取得したAPIキーをフォームに入力してください。
+              <div className="my-16">
+                APIキーは
+                <Link
+                  url="https://platform.openai.com/account/api-keys"
+                  label="OpenAIのサイト"
+                />
+                で取得できます。取得したAPIキーをフォームに入力してください。
+              </div>
+              <div className="my-16">
+                入力されたAPIキーで、ブラウザから直接OpenAIのAPIを利用しますので、サーバー等には保存されません。
+                なお、利用しているモデルはGPT-3です。
+                <br />
+                ※APIキーや会話文はピクシブのサーバーに送信されません。
+              </div>
             </div>
-            <div className="my-16">
-              入力されたAPIキーで、ブラウザから直接OpenAIのAPIを利用しますので、サーバー等には保存されません。
-              なお、利用しているモデルはGPT-3です。
-              <br />
-              ※APIキーや会話文はピクシブのサーバーに送信されません。
-            </div>
+            ) : (
+              <>
+                <div className="my-8">
+                  <div className="mt-16">
+                    APIキー
+                  </div>
+                  <input
+                    type="text"
+                    placeholder="YOUR_API_KEY"
+                    value={azureOpenAiKey}
+                    onChange={onChangeAzureOpenAiKey}
+                    className="text-ellipsis px-16 py-8 w-full bg-surface1 hover:bg-surface1-hover rounded-8"
+                  />
+                </div>
+                <div className="my-8">
+                  <div className="mt-16">
+                    リソース名
+                  </div>
+                  <input
+                    type="text"
+                    placeholder="YOUR_RESOURCE_NAME"
+                    value={azureOpenAiResourceName}
+                    onChange={onChangeAzureOpenAiResourceName}
+                    className="text-ellipsis px-16 py-8 w-full bg-surface1 hover:bg-surface1-hover rounded-8"
+                  />
+                </div>
+                <div className="my-8">
+                  <div className="mt-16">
+                    モデルのデプロイ名
+                  </div>
+                  <input
+                    type="text"
+                    placeholder="YOUR_DEPLOYMENT_NAME"
+                    value={azureOpenAiDeploymentName}
+                    onChange={onChangeAzureOpenAiDeploymentName}
+                    className="text-ellipsis px-16 py-8 w-full bg-surface1 hover:bg-surface1-hover rounded-8"
+                  />
+                </div>
+                <div className="my-16">
+                  <Link
+                    url="https://learn.microsoft.com/ja-jp/azure/cognitive-services/openai/reference"
+                    label="Azure OpenAI ServiceのREST APIリファレンス"
+                  />
+                  を参考にして各項目を入力してください。
+                </div>
+                <div className="my-16">
+                  入力されたAPIキーで、ブラウザから直接Azure OpenAI ServiceのAPIを利用しますので、サーバー等には保存されません。
+                  <br />
+                  ※APIキーや会話文はピクシブのサーバーに送信されません。
+                </div>
+              </>
+            )}
           </div>
           <div className="my-40">
             <div className="my-16 typography-20 font-bold">

--- a/src/features/chat/openAiChat.ts
+++ b/src/features/chat/openAiChat.ts
@@ -49,6 +49,47 @@ export async function getChatResponseStream(
     }),
   });
 
+  return readChatResponseStream(res);
+}
+
+export async function getAzureChatResponseStream(
+  messages: Message[],
+  apiKey: string,
+  resourceName: string,
+  deploymentName: string
+) {
+  if (!apiKey) {
+    throw new Error("Invalid API Key");
+  }
+  if (!resourceName) {
+    throw new Error("Invalid Resource Name");
+  }
+  if (!deploymentName) {
+    throw new Error("Invalid Deployment Name");
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "api-key": apiKey,
+  };
+
+  const apiVersion = "2023-03-15-preview";
+  const res = await fetch(`https://${resourceName}.openai.azure.com/openai/deployments/${deploymentName}/chat/completions?api-version=${apiVersion}`, {
+    headers: headers,
+    method: "POST",
+    body: JSON.stringify({
+      messages: messages,
+      stream: true,
+      max_tokens: 200,
+    }),
+  });
+
+  return readChatResponseStream(res);
+}
+
+async function readChatResponseStream(
+  res: Response
+): Promise<ReadableStream> {
   const reader = res.body?.getReader();
   if (res.status !== 200 || !reader) {
     throw new Error("Something went wrong");


### PR DESCRIPTION
# PR概要
ユーザーの利便性を上げるため、OpenAIのChatGPTに加えて、Azure OpenAI ServiceのChatGPTも選べるように変更しました。変更内容を確認頂き、本アプリの方針に沿うようでしたら、マージ頂けますと大変幸いです。

Azure OpenAI Serviceの開始方法については次のZennの記事が分かりやすいのでご参考ください。
[Azure OpenAI Service を使い始める](https://zenn.dev/microsoft/articles/1a15305021cd01#%E5%88%A9%E7%94%A8%E9%96%8B%E5%A7%8B%E3%81%BE%E3%81%A7%E3%81%AE%E6%89%8B%E9%A0%86)

# エビデンス
以下はローカルでAzure OpenAI ServiceのChatGPTの動作を確認した際のキャプチャです。

## イントロダクション
IntroductionでOpenAIとAzure OpenAI Serviceをリストボックスで選べるように（初期表示はOpenAI）
![image](https://user-images.githubusercontent.com/42795291/235561550-2c45885a-8837-4017-9e6d-9bcd015d21d7.png)

プロバイダーをAzure OpenAI Serviceに切り替えると入力項目が変更される
![image](https://user-images.githubusercontent.com/42795291/235561728-cd7cad35-ceb2-4d7a-9604-e9b684544da8.png)

Azure OpenAI Serviceの入力項目を埋めた後の状態（機微情報はマスキングしています）
![image](https://user-images.githubusercontent.com/42795291/235561766-317947a7-e345-4853-9672-d2ec026dc6a4.png)

## キャラクターとの会話
リクエストを送るとAzure OpenAI ServiceのChatGPTで生成されたレスポンスが返ってくる
![image](https://user-images.githubusercontent.com/42795291/235561866-4326efca-8608-423b-87f5-9700d8acac76.png)
![image](https://user-images.githubusercontent.com/42795291/235561882-a1c64542-a3b6-4647-82a9-227566bc18f3.png)

## 設定
![image](https://user-images.githubusercontent.com/42795291/235561988-bcacefb0-9315-435d-90cd-a83520e93daa.png)
![image](https://user-images.githubusercontent.com/42795291/235562014-cf2c90d6-0c44-4357-ac18-a0afa896961a.png)