### PR TITLE
タブを消したりリロードしたりしても会話ログとキャラ設定、koeiroの設定を引き継ぐようにする変更

### DIFF
--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -17,6 +17,8 @@ type Props = {
   onChangeAiKey: (key: string) => void;
   onChangeChatLog: (index: number, text: string) => void;
   onChangeKoeiromapParam: (param: KoeiroParam) => void;
+  handleClickResetChatLog: () => void;
+  handleClickResetSystemPrompt: () => void;
 };
 export const Menu = ({
   openAiKey,
@@ -28,6 +30,8 @@ export const Menu = ({
   onChangeAiKey,
   onChangeChatLog,
   onChangeKoeiromapParam,
+  handleClickResetChatLog,
+  handleClickResetSystemPrompt,
 }: Props) => {
   const [showSettings, setShowSettings] = useState(false);
   const [showChatLog, setShowChatLog] = useState(false);
@@ -124,6 +128,8 @@ export const Menu = ({
           onChangeChatLog={onChangeChatLog}
           onChangeKoeiroParam={handleChangeKoeiroParam}
           onClickOpenVrmFile={handleClickOpenVrmFile}
+          onClickResetChatLog={handleClickResetChatLog}
+          onClickResetSystemPrompt={handleClickResetSystemPrompt}
         />
       )}
       {!showChatLog && assistantMessage && (

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -22,6 +22,8 @@ type Props = {
   onChangeChatLog: (index: number, text: string) => void;
   onChangeKoeiroParam: (x: number, y: number) => void;
   onClickOpenVrmFile: () => void;
+  onClickResetChatLog: () => void;
+  onClickResetSystemPrompt: () => void;
 };
 export const Settings = ({
   openAiKey,
@@ -34,6 +36,8 @@ export const Settings = ({
   onChangeChatLog,
   onChangeKoeiroParam,
   onClickOpenVrmFile,
+  onClickResetChatLog,
+  onClickResetSystemPrompt,
 }: Props) => {
   return (
     <div className="absolute z-40 w-full h-full bg-white/80 backdrop-blur ">
@@ -80,8 +84,13 @@ export const Settings = ({
             </div>
           </div>
           <div className="my-40">
-            <div className="my-16 typography-20 font-bold">
-              キャラクター設定（システムプロンプト）
+            <div className="my-8">
+              <div className="my-16 typography-20 font-bold">
+                キャラクター設定（システムプロンプト）
+              </div>
+              <TextButton onClick={onClickResetSystemPrompt}>
+                キャラクター設定リセット
+              </TextButton>
             </div>
 
             <textarea
@@ -170,7 +179,12 @@ export const Settings = ({
           </div>
           {chatLog.length > 0 && (
             <div className="my-40">
-              <div className="my-16 typography-20 font-bold">会話履歴</div>
+              <div className="my-8 grid-cols-2">
+                <div className="my-16 typography-20 font-bold">会話履歴</div>
+                <TextButton onClick={onClickResetChatLog}>
+                  会話履歴リセット
+                </TextButton>
+              </div>
               <div className="my-8">
                 {chatLog.map((value, index) => {
                   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import VrmViewer from "@/components/vrmViewer";
 import { ViewerContext } from "@/features/vrmViewer/viewerContext";
 import {
@@ -38,6 +38,28 @@ export default function Home() {
   const [chatProcessing, setChatProcessing] = useState(false);
   const [chatLog, setChatLog] = useState<Message[]>([]);
   const [assistantMessage, setAssistantMessage] = useState("");
+
+  useEffect(() => {
+    console.log("読み出し");
+    if (window.localStorage.getItem("chatVRMParams")) {
+      const params = JSON.parse(
+        window.localStorage.getItem("chatVRMParams") as string
+      );
+      setSystemPrompt(params.systemPrompt);
+      setKoeiroParam(params.koeiroParam);
+      setChatLog(params.chatLog);
+    }
+  }, []);
+
+  useEffect(() => {
+    console.log("書き出し");
+    process.nextTick(() =>
+      window.localStorage.setItem(
+        "chatVRMParams",
+        JSON.stringify({ systemPrompt, koeiroParam, chatLog })
+      )
+    );
+  }, [systemPrompt, koeiroParam, chatLog]);
 
   const handleChangeChatLog = useCallback(
     (targetIndex: number, text: string) => {
@@ -195,6 +217,8 @@ export default function Home() {
         onChangeSystemPrompt={setSystemPrompt}
         onChangeChatLog={handleChangeChatLog}
         onChangeKoeiromapParam={setKoeiroParam}
+        handleClickResetChatLog={() => setChatLog([])}
+        handleClickResetSystemPrompt={() => setSystemPrompt(SYSTEM_PROMPT)}
       />
       <GitHubLink />
     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,7 +40,6 @@ export default function Home() {
   const [assistantMessage, setAssistantMessage] = useState("");
 
   useEffect(() => {
-    console.log("読み出し");
     if (window.localStorage.getItem("chatVRMParams")) {
       const params = JSON.parse(
         window.localStorage.getItem("chatVRMParams") as string
@@ -52,7 +51,6 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    console.log("書き出し");
     process.nextTick(() =>
       window.localStorage.setItem(
         "chatVRMParams",


### PR DESCRIPTION
# PR概要
いくつかの設定をローカルストレージに保存してタブを消したりリロードしたりしても引き継ぐようにしました。
- chatLog
- koeiroParam
- systemPrompt

また、chatLog、systemPromptに関してはリセットできるようにしています。

# 設定画面
<img width="100%" alt="スクリーンショット 2023-05-03 23 15 20" src="https://user-images.githubusercontent.com/22505286/235942635-c04696f5-dbc7-49dc-a53b-9261635163d2.png">
キャラ設定リセット
<img width="100%" alt="スクリーンショット 2023-05-03 23 15 32" src="https://user-images.githubusercontent.com/22505286/235942796-4151a8ae-3418-4f7b-8ead-9b9fad00288d.png">
会話ログリセット
