### PR TITLE
actionsでデプロイするgh-pages用のブランチを変更する

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -7,7 +7,7 @@ name: Deploy Next.js site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["old/gh-pages"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
https://github.com/pixiv/ChatVRM/pull/10 で[API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)を使用するように変更するためGitHub Pagesでは動作しなくなります。
本MRではGitHub Pagesで公開するブランチを`old/gh-pages`へ変更し、旧バージョンのデモを維持します。

ただし、旧バージョンのデモはKoeiro API (v0)の提供終了に伴い2023/7/18以降動作しなくなります