### PR TITLE
旧デモの提供終了のメッセージと新デモへの動線を追加

### DIFF
--- a/src/components/githubLink.tsx
+++ b/src/components/githubLink.tsx
@@ -2,7 +2,7 @@ import { buildUrl } from "@/utils/buildUrl";
 
 export const GitHubLink = () => {
   return (
-    <div className="absolute right-0 z-10 m-24">
+    <div>
       <a
         draggable={false}
         href="https://github.com/pixiv/ChatVRM"
@@ -10,13 +10,15 @@ export const GitHubLink = () => {
         target="_blank"
       >
         <div className="p-8 rounded-16 bg-[#1F2328] hover:bg-[#33383E] active:bg-[565A60] flex">
-          <img
-            alt="https://github.com/pixiv/ChatVRM"
-            height={24}
-            width={24}
-            src={buildUrl("/github-mark-white.svg")}
-          ></img>
-          <div className="mx-4 text-white font-M_PLUS_2 font-bold">Fork me</div>
+          <div className="w-[24px]">
+            <img
+              alt="https://github.com/pixiv/ChatVRM"
+              height={24}
+              width={24}
+              src={buildUrl("/github-mark-white.svg")}
+            ></img>
+          </div>
+          <div className="mx-8 text-white font-M_PLUS_2 font-bold">Fork me</div>
         </div>
       </a>
     </div>

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -92,14 +92,14 @@ export const Menu = ({
     <>
       <div className="absolute z-10 w-full font-M_PLUS_2">
         <div className="px-24 py-4 mb-8 text-center text-primary bg-white">
-          Koeiro
-          APIの提供終了により、このデモは2023/7/18以降はご利用いただけません。
+          Koemotionの正式リリースに伴い、
           <a
             href="https://chatvrm.glitch.me"
             className="text-secondary hover:text-secondary-hover active:text-secondary-press"
           >
-            Koeiromap 1.0対応版はこちら
+            Koeiromap 1.0対応版
           </a>
+          を公開しました。このページのデモは2023/7/18以降はご利用いただけません。
         </div>
         <div
           className="px-24 grid grid-flow-col 

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -95,7 +95,7 @@ export const Menu = ({
           Koeiro
           APIの提供終了により、このデモは2023/7/18以降はご利用いただけません。
           <a
-            href=""
+            href="https://chatvrm.glitch.me"
             className="text-secondary hover:text-secondary-hover active:text-secondary-press"
           >
             Koeiromap 1.0対応版はこちら

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useContext, useRef, useState } from "react";
 import { Settings } from "./settings";
 import { ViewerContext } from "@/features/vrmViewer/viewerContext";
 import { AssistantText } from "./assistantText";
+import { GitHubLink } from "./githubLink";
 
 type Props = {
   openAiKey: string;
@@ -89,8 +90,22 @@ export const Menu = ({
 
   return (
     <>
-      <div className="absolute z-10 m-24">
-        <div className="grid grid-flow-col gap-[8px]">
+      <div className="absolute z-10 w-full font-M_PLUS_2">
+        <div className="px-24 py-4 mb-8 text-center text-primary bg-white">
+          Koeiro
+          APIの提供終了により、このデモは2023/7/18以降はご利用いただけません。
+          <a
+            href=""
+            className="text-secondary hover:text-secondary-hover active:text-secondary-press"
+          >
+            Koeiromap 1.0対応版はこちら
+          </a>
+        </div>
+        <div
+          className="px-24 grid grid-flow-col 
+        grid-cols-[min-content_min-content_1fr_min-content]
+        gap-[8px] auto-cols-min whitespace-nowrap"
+        >
           <IconButton
             iconName="24/Menu"
             label="設定"
@@ -113,6 +128,8 @@ export const Menu = ({
               onClick={() => setShowChatLog(true)}
             />
           )}
+          <div></div>
+          <GitHubLink />
         </div>
       </div>
       {showChatLog && <ChatLog messages={chatLog} />}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -218,7 +218,6 @@ export default function Home() {
         handleClickResetChatLog={() => setChatLog([])}
         handleClickResetSystemPrompt={() => setSystemPrompt(SYSTEM_PROMPT)}
       />
-      <GitHubLink />
     </div>
   );
 }


### PR DESCRIPTION
GitHub Pagesのデモページ上部に提供終了の告知を表示します。

それに合わせてGitHub Linkのレイアウトを調整しました。

**GitHub Pages用の変更なのでマージ先は[old/gh-pages](https://github.com/pixiv/ChatVRM/tree/old/gh-pages)です。**